### PR TITLE
Readme: add -j to Protobuf build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Follow these steps to build all components:
     tar -xzf protobuf-all-21.12.tar.gz
     cd protobuf-21.12/
     ./configure --disable-shared CXXFLAGS="-fPIC"
-    make -j 12
+    make -j12
     sudo make install
     sudo ldconfig
     ```


### PR DESCRIPTION
Hi,

I think it's a good idea to also include the `-j` flag in the Protobuf build instructions to speed up the installation process.

Best
Jan